### PR TITLE
Add support for defining QubesOS repository mirror

### DIFF
--- a/prepare-chroot-builder
+++ b/prepare-chroot-builder
@@ -112,6 +112,9 @@ if [ -n "$USE_QUBES_REPO_VERSION" ]; then
     if [ "$DIST" = "$DIST_DOM0" ]; then
         cp ${PLUGIN_DIR}/repos/qubes-repo-dom0-fedora.repo $DIR/etc/yum.repos.d/
     fi
+    if [ "x$QUBES_MIRROR" != "x" ]; then
+        sed -i "s#baseurl.*yum.qubes-os.org#baseurl = $QUBES_MIRROR#" $DIR/etc/yum.repos.d/qubes-repo-*.repo
+    fi
     sed -i -e "s#%DIST%#$DIST#" $DIR/etc/yum.repos.d/qubes-repo-*.repo
     sed -i -e "s#%QUBESVER%#$USE_QUBES_REPO_VERSION#" $DIR/etc/yum.repos.d/qubes-repo-*.repo
 

--- a/template_scripts/04_install_qubes.sh
+++ b/template_scripts/04_install_qubes.sh
@@ -11,6 +11,9 @@ if [ -n "$USE_QUBES_REPO_VERSION" ]; then
     sed -e "s/%QUBESVER%/$USE_QUBES_REPO_VERSION/g" \
         < ${SCRIPTSDIR}/../repos/qubes-repo-vm-$DISTRIBUTION.repo \
         > ${INSTALLDIR}/etc/yum.repos.d/template-qubes-vm.repo
+    if [ "x$QUBES_MIRROR" != "x" ]; then
+        sed -i "s#baseurl.*yum.qubes-os.org#baseurl = $QUBES_MIRROR#" ${INSTALLDIR}/etc/yum.repos.d/template-qubes-vm.repo
+    fi
     keypath="${BUILDER_DIR}/qubes-release-${USE_QUBES_REPO_VERSION}-signing-key.asc"
     if [ -r "$keypath" ]; then
         # use stdin to not copy the file into chroot. /dev/stdin


### PR DESCRIPTION
I thought to replace the hardcoded URL of Qubes in a variable or to add a placeholder inside the repo files. What do you think?