### PR TITLE
Use Source0: tag for archive name

### DIFF
--- a/Makefile.rpmbuilder
+++ b/Makefile.rpmbuilder
@@ -13,9 +13,10 @@ DIST_BUILD_DIR = /home/user
 
 ifneq (1,$(NO_ARCHIVE))
 # allow Makefile.builder in component to override this value
-GIT_TARBALL_NAME ?= $(shell ORIG_SRC=$(ORIG_SRC) $(RPM_PLUGIN_DIR)scripts/query-spec \
-		"$(ORIG_SRC)/$(firstword $(RPM_SPEC_FILES))" "%{NAME}-%{VERSION}.tar.gz\n"\
-		| head -n 1)
+GIT_TARBALL_NAME ?= $(notdir \
+		$(shell ORIG_SRC=$(ORIG_SRC) $(RPM_PLUGIN_DIR)scripts/query-spec \
+		"$(ORIG_SRC)/$(firstword $(RPM_SPEC_FILES))" "%{SOURCE0}"\
+		| cut -d ' ' -f 2))
 endif
 
 ### Local variables

--- a/scripts/query-spec
+++ b/scripts/query-spec
@@ -21,8 +21,16 @@ if [ -r "${1}.in" ]; then
     # need to create a file due to a bug in process substitution (e.g. artwork package)
     tmp_spec=$(mktemp --tmpdir tmp.XXXXXX.spec)
     $(dirname $0)/generate-spec "${1}.in" "${tmp_spec}" 2> $ERR_OUTPUT
-    rpm -q $RPM_QUERY_DEFINES --qf "$2" --specfile "${tmp_spec}" 2> $ERR_OUTPUT
+    if [ "$2" = "%{SOURCE0}" ]; then
+        $(dirname "$0")/../tools/spectool --list-files --source 0 "${tmp_spec}" 2> $ERR_OUTPUT
+    else
+        rpm -q $RPM_QUERY_DEFINES --qf "$2" --specfile "${tmp_spec}" 2> $ERR_OUTPUT
+    fi
     rm -f "${tmp_spec}"
 else
-    rpm -q $RPM_QUERY_DEFINES --qf "$2" --specfile "$1" 2> $ERR_OUTPUT
+    if [ "$2" = "%{SOURCE0}" ]; then
+        $(dirname "$0")/../tools/spectool --list-files --source 0 "$1" 2> $ERR_OUTPUT
+    else
+        rpm -q $RPM_QUERY_DEFINES --qf "$2" --specfile "$1" 2> $ERR_OUTPUT
+    fi
 fi


### PR DESCRIPTION
Using "%{NAME}-%{VERSION}.tar.gz" is fragile, especially when multiple
packages are built from the single repository (package order matters
then). Use Source0 tag for archive name, to mitigate this problem and
also allow more flexible archive naming.

Unfortunately, rpm -q doesn't provide tag for getting Source0, use
spectool instead.