### PR TITLE
Install python2-futures in minimal template as a workaround for salt bug

### DIFF
--- a/template_scripts/packages_fc_minimal.list
+++ b/template_scripts/packages_fc_minimal.list
@@ -2,6 +2,7 @@ xterm
 tar
 haveged
 sudo
+python2-futures
 --exclude=kdegames
 --exclude=firstboot
 --exclude=xorg-x11-drv-nouveau


### PR DESCRIPTION
The missing module in salt thin is already fixed upstream and queued for
2018.3.3 (at least). This commit should be reverted when it gets
released and packaged in some Qubes-supported template.

Add the package only to minimal template, as it is already pulled in by
salt itself in other templates.

QubesOS/qubes-issues#4272