### PR TITLE
Make rpm packages reproducible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,22 @@ jobs:
   include:
     - env: TEST=shellcheck
       script: shellcheck prepare-chroot-base prepare-chroot-builder update-local-repo.sh scripts/*
+    # example VM package, without upstream tarball
+    - script: ~/qubes-builder/scripts/travis-build core-vchan-xen
+      env: DISTS_VM=fc29 USE_QUBES_REPO_VERSION=4.1 USE_QUBES_REPO_TESTING=1
+    # example dom0 package
+    - script: ~/qubes-builder/scripts/travis-build linux-utils
+      env: DIST_DOM0=fc29 USE_QUBES_REPO_VERSION=4.1 USE_QUBES_REPO_TESTING=1
+    # example package, with upstream tarball
+    - script: ~/qubes-builder/scripts/travis-build linux-scrypt
+      env: DISTS_VM=fc29 USE_QUBES_REPO_VERSION=4.1 USE_QUBES_REPO_TESTING=1
+    # example centos7 package, with upstream tarball and no qubes repos
+    - script: ~/qubes-builder/scripts/travis-build python-u2flib-host
+      env: DISTS_VM=centos7
+    # example package with src.rpms
+    - script: ~/qubes-builder/scripts/travis-build linux-dom0-updates
+      env: DIST_DOM0=fc25 BRANCH_linux_dom0_updates=release4.0
+
 
 # don't build tags which are meant for code signing only
 branches:

--- a/Makefile-mock.rpmbuilder
+++ b/Makefile-mock.rpmbuilder
@@ -76,7 +76,7 @@ dist-copy-out:
 	echo -n > $(pkg_list_path);\
 	for pkg in $(CHROOT_DIR)/$(DIST_SRC)/$(OUTPUT_DIR)/**/*.rpm; do\
 		relative_path=`realpath --relative-to=$(CHROOT_DIR)/$(DIST_SRC) $$pkg`;\
-		echo "      $(ORIG_SRC)/$(OUTPUT_DIR)/$$relative_path" >&3 ;\
+		echo "      $(ORIG_SRC)/$$relative_path" >&3 ;\
 		echo "$$relative_path" >> $(pkg_list_path);\
 	done;\
 	mkdir -p $(BUILDER_REPO_DIR)/rpm;\

--- a/Makefile-mock.rpmbuilder
+++ b/Makefile-mock.rpmbuilder
@@ -31,6 +31,10 @@ MOCK_ENV = DIST=$(DIST) \
 spec_pkg_name = $(shell cd $(ORIG_SRC) && [ -n "$(1)" ] && \
 	rpm -q $(RPM_QUERY_DEFINES) --qf '%{NAME}\n' --specfile $(1) | head -n 1)
 
+# full name with version of base package - useful for src.rpm name build
+spec_pkg_ver_name = $(shell cd $(ORIG_SRC) && [ -n "$(1)" ] && \
+    rpm -q $(RPM_QUERY_DEFINES) --qf '%{NAME}-%{VERSION}-%{RELEASE}\n' --specfile $(1) | head -n 1)
+
 ### Targets required by Makefile.generic to build packages
 dist-prepare-chroot:
 	mkdir -p $(CHROOT_DIR)/home/user/qubes-src
@@ -50,7 +54,7 @@ dist-src-package-build:
 ifeq ($(suffix $(PACKAGE)),.rpm)
 dist-package-build: srcrpm = $(PACKAGE)
 else
-dist-package-build: srcrpm = $(CHROOT_DIR)$(DIST_SRC)/$(OUTPUT_DIR)/$(call spec_pkg_name,$(CHROOT_DIR)$(DIST_SRC)/$(PACKAGE))*src.rpm
+dist-package-build: srcrpm = $(CHROOT_DIR)$(DIST_SRC)/$(OUTPUT_DIR)/$(call spec_pkg_ver_name,$(CHROOT_DIR)$(DIST_SRC)/$(PACKAGE)).src.rpm
 dist-package-build: dist-src-package-build
 endif
 dist-package-build:

--- a/Makefile-mock.rpmbuilder
+++ b/Makefile-mock.rpmbuilder
@@ -57,6 +57,7 @@ else
 dist-package-build: srcrpm = $(CHROOT_DIR)$(DIST_SRC)/$(OUTPUT_DIR)/$(call spec_pkg_ver_name,$(CHROOT_DIR)$(DIST_SRC)/$(PACKAGE)).src.rpm
 dist-package-build: dist-src-package-build
 endif
+dist-package-build: buildinfo = $(notdir $(srcrpm:%.src.rpm=%.$(RPM_ARCH).buildinfo))
 dist-package-build:
 ifndef PACKAGE
 	$(error "PACKAGE need to be set!")
@@ -70,6 +71,13 @@ endif
 		-v -r $(RPM_PLUGIN_DIR)/$(MOCK_CFG) \
 		$(MOCK_EXTRA_OPTS) --no-cleanup-after \
 		$(RPM_BUILD_DEFINES) --rebuild $(srcrpm)
+	sudo $(MOCK_ENV) $(MOCK) \
+		'--plugin-option=bind_mount:dirs=[("$(RPM_PLUGIN_DIR)", "/builder-rpm")]' \
+		-q -r $(RPM_PLUGIN_DIR)/$(MOCK_CFG) \
+		$(MOCK_EXTRA_OPTS) \
+		$(RPM_BUILD_DEFINES) --chroot \
+		'/builder-rpm/scripts/rpmbuildinfo /builddir/build/SRPMS/$(notdir $(srcrpm))' \
+		> $(CHROOT_DIR)/$(DIST_SRC)/$(OUTPUT_DIR)/$(buildinfo)
 
 dist-copy-out: pkg_list_path = $(ORIG_SRC)/$(OUTPUT_DIR)/$(notdir $(PACKAGE)).list
 dist-copy-out:
@@ -78,12 +86,16 @@ dist-copy-out:
 	shopt -s nullglob; shopt -s globstar;\
 	mkdir -p "$(ORIG_SRC)/$(OUTPUT_DIR)";\
 	echo -n > $(pkg_list_path);\
-	for pkg in $(CHROOT_DIR)/$(DIST_SRC)/$(OUTPUT_DIR)/**/*.rpm; do\
+	for pkg in $(CHROOT_DIR)/$(DIST_SRC)/$(OUTPUT_DIR)/**/*.rpm \
+			$(CHROOT_DIR)/$(DIST_SRC)/$(OUTPUT_DIR)/*.buildinfo; do\
 		relative_path=`realpath --relative-to=$(CHROOT_DIR)/$(DIST_SRC) $$pkg`;\
 		echo "      $(ORIG_SRC)/$$relative_path" >&3 ;\
 		echo "$$relative_path" >> $(pkg_list_path);\
 	done;\
 	mkdir -p $(BUILDER_REPO_DIR)/rpm;\
 	ln -f -t $(BUILDER_REPO_DIR)/rpm $(CHROOT_DIR)/$(DIST_SRC)/$(OUTPUT_DIR)/**/*.rpm;\
-	mv -t $(ORIG_SRC)/$(OUTPUT_DIR) $(CHROOT_DIR)/$(DIST_SRC)/$(OUTPUT_DIR)/**/*.rpm
+	ln -f -t $(BUILDER_REPO_DIR)/rpm $(CHROOT_DIR)/$(DIST_SRC)/$(OUTPUT_DIR)/*.buildinfo;\
+	mv -t $(ORIG_SRC)/$(OUTPUT_DIR) $(CHROOT_DIR)/$(DIST_SRC)/$(OUTPUT_DIR)/**/*.rpm;\
+	mv $(CHROOT_DIR)/$(DIST_SRC)/$(OUTPUT_DIR)/*.buildinfo \
+		$(ORIG_SRC)/$(OUTPUT_DIR)/
 

--- a/Makefile.rpmbuilder
+++ b/Makefile.rpmbuilder
@@ -26,6 +26,8 @@ ifndef OUTPUT_DIR
 OUTPUT_DIR= rpm
 endif
 
+RPM_ARCH := $(shell uname -m)
+
 # Use += to allow Makefile.builder define some initial value
 RPM_BUILD_DEFINES += --define "dist .$(DIST)"
 

--- a/Makefile.rpmbuilder
+++ b/Makefile.rpmbuilder
@@ -71,9 +71,12 @@ endif
 
 endif
 
+BUILDINFO_SIGN_CMD ?= $(firstword $(GNUPG) gpg2)
+BUILDINFO_SIGN_CMD += --clearsign
 RPMSIGN_OPTS ?=
 RPMSIGN_OPTS += --digest-algo=sha256
 ifneq (,$(SIGN_KEY))
+BUILDINFO_SIGN_CMD += --local-user $(SIGN_KEY)
 RPMSIGN_OPTS += --key-id=$(SIGN_KEY)
 endif
 
@@ -172,8 +175,13 @@ sign:
 ifeq (,$(PACKAGE_LIST))
 	@true
 else
+# buildinfo should be the last on the list, so update-rpmbuildinfo will
+# collect hashes of already signed packages
 	@cd $(ORIG_SRC) && for pkg in $(packages); do \
-		if ! rpm -K $$pkg | grep -qi pgp; then \
+		if [ "$${pkg##*.}" = "buildinfo" ]; then \
+			$(RPM_PLUGIN_DIR)scripts/update-rpmbuildinfo "$$pkg" | $(BUILDINFO_SIGN_CMD) > "$$pkg".tmp && \
+			mv -f "$$pkg".tmp "$$pkg"; \
+		elif ! rpm -K $$pkg | grep -qi pgp; then \
 			setsid -w rpmsign $(RPMSIGN_OPTS) --addsign $$pkg </dev/null || exit 1; \
 		fi; \
 	done

--- a/mock-centos.cfg
+++ b/mock-centos.cfg
@@ -13,6 +13,10 @@ config_opts['releasever'] = os.environ['DIST'].replace('centos', '')
 config_opts['package_manager'] = 'yum'
 config_opts['nosync'] = True
 config_opts['nosync_force'] = True
+config_opts['macros']['source_date_epoch_from_changelog'] = 'Y'
+config_opts['macros']['clamp_mtime_to_source_date_epoch'] = 'Y'
+config_opts['macros']['use_source_date_epoch_as_buildtime'] = 'Y'
+config_opts['macros']['_buildhost'] = 'reproducible'
 
 config_opts['yum.conf'] = """
 [main]

--- a/mock-fedora.cfg
+++ b/mock-fedora.cfg
@@ -13,6 +13,10 @@ config_opts['releasever'] = os.environ['DIST'].replace('fc', '')
 config_opts['package_manager'] = 'dnf'
 config_opts['nosync'] = True
 config_opts['nosync_force'] = True
+config_opts['macros']['source_date_epoch_from_changelog'] = 'Y'
+config_opts['macros']['clamp_mtime_to_source_date_epoch'] = 'Y'
+config_opts['macros']['use_source_date_epoch_as_buildtime'] = 'Y'
+config_opts['macros']['_buildhost'] = 'reproducible'
 
 config_opts['yum.conf'] = """
 [main]

--- a/scripts/generate-changelog
+++ b/scripts/generate-changelog
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+# Based on PLD Linux:
+# https://git.pld-linux.org/?p=packages/rpm-build-tools.git;a=blob;f=builder.sh;h=3c9a33648d2cb1b1410939c16637c7d9cac3b09d;hb=HEAD#l468
+
+# create tempfile. as secure as possible
+my_tempfile() {
+        prefix=builder.$PACKAGE_NAME
+        mktemp --tmpdir -t "$prefix.XXXXXX"
+}
+
+ORIG_SRC="$1"
+SPECFILE="$2"
+gitlog=$(my_tempfile) speclog=$(my_tempfile)
+
+log_entries=50
+
+# rpm5.org/rpm.org do not parse any other date format than 'Wed Jan 1 1997'
+# otherwise i'd use --date=iso here
+# http://rpm5.org/cvs/fileview?f=rpm/build/parseChangelog.c&v=2.44.2.1
+# http://rpm.org/gitweb?p=rpm.git;a=blob;f=build/parseChangelog.c;h=56ba69daa41d65ec9fd18c9f371b8ff14118cdca;hb=a113baa510a004476edc44b5ebaaf559238a18b6#l33
+# NOTE: changelog date is always in UTC for rpmbuild
+# * 1265749244 +0000 Random Hacker <nikt@pld-linux.org> 9370900
+git -C "$ORIG_SRC" rev-list --date-order -${log_entries:-20} HEAD 2>/dev/null | while read -r sha1; do
+        git -C "$ORIG_SRC" log -n 1 "$sha1" --format=format:"* %cd %an <%ae> - %h%n- %s%n%n" --date=raw | sed -re 's/^- +- */- /'| sed '/^$/q'
+done > "$gitlog"
+
+# add link to full git logs
+giturl="https://github.com/QubesOS/qubes-${COMPONENT}"
+gitauthor="Qubes OS Team <qubes-devel@groups.google.com>"
+gitdate=$(git -C "$ORIG_SRC" log -n 1 --date=raw --format=format:"%cd")
+LC_ALL=C gawk -vgiturl="$giturl" -vgitauthor="$gitauthor" -vgitdate="$gitdate" 'BEGIN{
+        printf("* %s %s\n- For complete changelog see: %s\n", strftime("%a %b %d %Y", gitdate), gitauthor, giturl);
+        print;
+        exit
+}' > "$speclog"
+
+LC_ALL=C gawk '/^\* /{printf("* %s %s\n", strftime("%a %b %d %Y", $2), substr($0, length($1)+length($2)+length($3)+4)); next}{print}' "$gitlog" >> "$speclog"
+sed -i -e "/@CHANGELOG@/{r ${speclog}" -e "d}" "$SPECFILE"
+rm -f "$gitlog" "$speclog"

--- a/scripts/generate-spec
+++ b/scripts/generate-spec
@@ -52,10 +52,8 @@ sed -i \
     -e "s:@BACKEND_VMM@:${BACKEND_VMM}:g" "$1.tmp"
 
 # Handle changelog
-if [ -e "${ORIG_SRC}/changelog" ]; then
-    sed -i -e "/@CHANGELOG@/{r ${ORIG_SRC}/changelog" -e "d}" "$1.tmp"
-else
-    sed -i '/@CHANGELOG@/d' "$1.tmp"
+if grep -q "@CHANGELOG@" "$1.tmp"; then
+    "$(dirname "$0")"/generate-changelog "${ORIG_SRC}" "$1.tmp"
 fi
 
 cat "$1.tmp" > "$2"

--- a/scripts/rpmbuildinfo
+++ b/scripts/rpmbuildinfo
@@ -1,0 +1,111 @@
+#!/bin/sh
+
+
+# Copyright (c) 2016  Bernhard M. Wiedemann <bernhard@zq1.de>
+# Copyright (c) 2016  Dennis Gilmore <dennis@ausil.us>
+# Copyright (c) 2016  Simon "HW42" Geiser <hw42@ipsumj.de>
+# Copyright (c) 2016  Wojciech Porczyk <woju@invisiblethingslab.com>
+#
+# All rights reserved.
+# 
+# Permission to use, copy, modify, and distribute this software for any purpose
+# with or without fee is hereby granted, provided that the above copyright
+# notice and this permission notice appear in all copies.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF THIRD PARTY RIGHTS. IN
+# NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+# DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+# OR OTHER DEALINGS IN THE SOFTWARE.
+# 
+# Except as contained in this notice, the name of a copyright holder shall not
+# be used in advertising or otherwise to promote the sale, use or other dealings
+# in this Software without prior written authorization of the copyright holder.
+#
+
+set -e
+
+getos()
+{
+    # shellcheck disable=SC1091
+    test -r /etc/os-release && . /etc/os-release
+    if test -n "$BUILD_ORIGIN"
+    then
+        ID="$BUILD_ORIGIN"
+    fi
+    if test -z "$ID"; then
+        ID=$(cat /etc/system-release)
+    fi
+    printf %s "$ID"
+}
+
+if test $# -lt 1
+then
+    echo usage: "$0" SRPM >&2
+    exit 2
+fi
+
+if [ "${1%.src.rpm}" = "$1" ]; then
+    SRPMDIR=$(rpm --eval '%{_srcrpmdir}')
+    SRPM="$SRPMDIR/$(rpm -qp --queryformat '%{SOURCERPM}' "$1")"
+    RPMS="$*"
+else
+    SRPM="$1"
+    RPMS=$(find "$(rpm --eval '%{_rpmdir}')" -name '*.rpm')
+fi
+
+if ! [ -e "$SRPM" ]; then
+    echo "$SRPM does not exist" >&2
+    exit 1
+fi
+
+# Build-Date: not from rpm because that will be $SOURCE_DATE_EPOCH
+# Binary: /usr/src/packages/RPMS/*/*.rpm or equivalent
+cat <<EOF
+Format: 0.2-rpm
+Build-Architecture: $(uname -m)
+Source: $(rpm -qp --queryformat '%{name}' "$SRPM")
+Version: $(rpm -qp --queryformat '%{version}-%{release}' "$SRPM")
+Architecture: $(rpm -qp --queryformat '%{arch}' "$SRPM")
+Binary: $(printf '%s' "$RPMS" | xargs rpm -qp --qf "%{name} ")
+Build-Origin: $(getos)
+Build-Date: $(date -R)
+Build-Path: $(rpm --eval '%{_builddir}')
+EOF
+
+printf 'Installed-Build-Depends:\n'
+rpm -qa --queryformat '%{epoch}:%{name}-%{version}\n' \
+    | LC_ALL=C sort -t: -k2 \
+    | sed -e 's/^(none)://' -e 's/^/ /'
+
+printf 'Environment:\n'
+
+# whitelist stolen from Debian's dpkg:
+# https://anonscm.debian.org/git/dpkg/dpkg.git/tree/scripts/Dpkg/Build/Info.pm#n50
+ENV_WHITELIST=
+
+# Toolchain.
+ENV_WHITELIST="$ENV_WHITELIST CC CPP CXX OBJC OBJCXX PC FC M2C AS LD AR RANLIB MAKE AWK LEX YACC"
+# Toolchain flags.
+ENV_WHITELIST="$ENV_WHITELIST CFLAGS CPPFLAGS CXXFLAGS OBJCFLAGS OBJCXXFLAGS GCJFLAGS FFLAGS LDFLAGS ARFLAGS MAKEFLAGS"
+# Dynamic linker, see ld(1).
+ENV_WHITELIST="$ENV_WHITELIST LD_LIBRARY_PATH"
+# Locale, see locale(1).
+ENV_WHITELIST="$ENV_WHITELIST LANG LC_ALL LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT LC_IDENTIFICATION"
+ENV_WHITELIST="$ENV_WHITELIST SOURCE_DATE_EPOCH"
+for var in $ENV_WHITELIST
+do
+    eval value="\$$var"
+    # shellcheck disable=SC2154
+    test -n "$value" && printf ' %s="%s"\n' "$var" "$value"
+done
+
+printf 'Checksum-Sha256:\n'
+for rpm in $SRPM $RPMS
+do
+    checksum=$(sha256sum -b "$rpm" | cut -c 1-64)
+    size=$(stat -c '%s' "$rpm")
+    printf ' %s %s %s\n' "$checksum" "$size" "$(basename "$rpm")"
+done

--- a/scripts/update-rpmbuildinfo
+++ b/scripts/update-rpmbuildinfo
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# Update rpm buildinfo file after signing packages
+
+# Usage: $0 <buildinfo file>
+# Updated builinfo file is printed to stdout
+# Packages referenced there are assumed to be present in the same directory
+# The script assumes Signed-Checksum-Sha256 (if any) is the last field and
+# Format: is the first
+
+set -e
+
+buildinfo="$1"
+[ -r "$buildinfo" ]
+
+dir="$(dirname "$buildinfo")"
+
+# Print everything until old Signed-Checksum-Sha256: header, skipping signature
+# header if any
+sed -n '/^Format:/,/^Signed-Checksum-Sha256:/{/^Signed-Checksum-Sha256/d; p}' < "$buildinfo"
+
+echo "Signed-Checksum-Sha256:"
+
+# Then, for each file listed in Checksum-Sha256, add it to Signed-Checksum-Sha256
+sed -n '/^Checksum-Sha256:/,/^[^ ]/{ /^ /p}' < "$buildinfo" |\
+while read -r _ size name; do
+    checksum=$(sha256sum -b "$dir/$name" | cut -c 1-64)
+    size=$(stat -c '%s' "$dir/$name")
+    printf ' %s %s %s\n' "$checksum" "$size" "$name"
+done


### PR DESCRIPTION
rpm >= 4.13 is capable of building reproducible rpms. Make use of it.

This work was done collectively with @HW42, during Reproducible Builds Summit.

QubesOS/qubes-issues#816

Tests to do before merging:
 - [ ] build all the R4.0 packages
 - [ ] build all the R4.0 packages again and check for any non-reproducible -> create separate issue if any
 - [ ] build all the R3.2 packages