### PR TITLE
Only add glibc-langpack-en for Fedora >= 25

### DIFF
--- a/prepare-chroot-base
+++ b/prepare-chroot-base
@@ -70,8 +70,10 @@ if ! [ -f "${INSTALLDIR}/tmp/.prepared_base" ]; then
 
     if [ "${DISTRIBUTION}" = "fedora" ]; then
         INITIAL_PACKAGES="filesystem setup fedora-release dnf dnf-plugins-core"
-        # avoid pulling in glibc-all-langpacks to save space
-        INITIAL_PACKAGES="$INITIAL_PACKAGES glibc-langpack-en"
+        if [ "${DIST_VER}" -ge 25 ]; then
+            # avoid pulling in glibc-all-langpacks to save space
+            INITIAL_PACKAGES="$INITIAL_PACKAGES glibc-langpack-en"
+        fi
 
         if [ "${DIST_VER}" -ge 26 ]; then
             # coreutils conflicts with coreutils-single


### PR DESCRIPTION
Typically, it does not exist for Fedora 23.