### PR TITLE
Remove Gnome Control Center from whitelisted apps

### DIFF
--- a/template_scripts/appmenus_fc/whitelisted-appmenus.list
+++ b/template_scripts/appmenus_fc/whitelisted-appmenus.list
@@ -1,4 +1,3 @@
 org.gnome.Terminal.desktop
 org.gnome.Software.desktop
 gpk-update-viewer.desktop
-gnome-control-center.desktop


### PR DESCRIPTION
tldr: an upstream bug (reported 2018-11-04 and still not fixed) prevents Gnome Control Center from working in fedora templates. I recommend not removing it from the whitelist.
ref: https://github.com/QubesOS/qubes-issues/issues/5433
Note: I'll see if Centos also has this issue.