### PR TITLE
Fedora: disable modular repositories

### DIFF
--- a/prepare-chroot-builder
+++ b/prepare-chroot-builder
@@ -162,3 +162,10 @@ chroot "$DIR" "$YUM" install -y $YUM_OPTS $PKGGROUPS
 if [ -n "$CHROOT_CACHE_FILE" ]; then
     tar cf "$CHROOT_CACHE_FILE" --one-file-system "$DIR"
 fi
+
+# Disable Fedora modular repos because
+# it can make dnf builddep to fail
+# resolving dependencies
+if [ "$DISTRIBUTION" = "fedora" ] && [ "${DIST_VER}" -ge 29 ]; then
+    chroot "$DIR" dnf config-manager --disable '*modular'
+fi


### PR DESCRIPTION
Currently, libvirt fails to build under Fedora 31 due to problem with dnf builddep which does not behave like dnf install. Disabling useless modular repositories for us solves the problem.