### PR TITLE
Mount /dev instead of creating it

### DIFF
--- a/Makefile-legacy.rpmbuilder
+++ b/Makefile-legacy.rpmbuilder
@@ -30,6 +30,9 @@ dist-prepare-chroot: $(CHROOT_DIR)/home/user/.prepared_base
 	@if [ ! -r $(CHROOT_DIR)/proc/cpuinfo ]; then\
 		sudo mount -t proc proc $(CHROOT_DIR)/proc;\
 	fi
+	@if ! [ -r $(CHROOT_DIR)/dev/null ]; then\
+		sudo mount -t devtmpfs devtmpfs $(CHROOT_DIR)/dev;\
+	fi
 	@if ! [ -d $(CHROOT_DIR)/tmp/qubes-packages-mirror-repo/rpm ]; then\
 		mkdir -p $(CHROOT_DIR)/tmp/qubes-packages-mirror-repo;\
 		sudo mount --bind $(BUILDER_REPO_DIR) $(CHROOT_DIR)/tmp/qubes-packages-mirror-repo;\

--- a/prepare-chroot-base
+++ b/prepare-chroot-base
@@ -214,19 +214,9 @@ if ! [ -f "${INSTALLDIR}/tmp/.prepared_base" ]; then
         set -x
     fi
 
-    # Prepare /dev nodes
-    mkdir -p "${INSTALLDIR}/dev/"
-    for f in null urandom zero random console; do
-        cp -a /dev/$f "$INSTALLDIR/dev/"
-    done
-
-    # Create loop devices as much as Mock does
-    mknod -m 0666 "$INSTALLDIR/dev/loop-control" c 10 237
-
-    for i in $(seq 0 4)
-    do
-        mknod -m 0666 "$INSTALLDIR/dev/loop$i" b 7 "$i"
-    done
+    # Prepare /dev
+    mkdir "$INSTALLDIR/dev"
+    mount -t devtmpfs devtmpfs "$INSTALLDIR/dev"
 
     echo "-> Installing core RPM packages..."
     rpm "${RPM_OPTS[@]}" -U --replacepkgs --root="${INSTALLDIR}" "${DOWNLOADDIR}/"*.rpm || exit 1

--- a/prepare-chroot-builder
+++ b/prepare-chroot-builder
@@ -48,12 +48,15 @@ if [ -f /etc/debian_version ]; then
 fi
 
 prepare_chroot_proc () {
-    mount -t proc proc "$DIR/proc"
+    if ! [ -r "$DIR/proc/cpuinfo" ]; then
+        mount -t proc proc "$DIR/proc"
+    fi
+}
 
-    chroot "$DIR" ln -nsf /proc/self/fd /dev/fd
-    chroot "$DIR" ln -nsf /proc/self/fd/0 /dev/stdin
-    chroot "$DIR" ln -nsf /proc/self/fd/1 /dev/stdout
-    chroot "$DIR" ln -snf /proc/self/fd/2 /dev/stderr
+prepare_chroot_dev () {
+    if ! [ -r "$DIR/dev/null" ]; then
+        mount -t devtmpfs devtmpfs "$DIR/dev"
+    fi
 }
 
 if ! [ -d "$DIR/home/user" ] && [ -r "$CHROOT_CACHE_FILE" ]; then
@@ -64,9 +67,7 @@ elif ! [ -d "$DIR/home/user/.prepared_base" ]; then
 
     "${PLUGIN_DIR}/prepare-chroot-base" "$DIR" "$DIST"
 
-    if ! [ -r "$DIR/proc/cpuinfo" ]; then
-        prepare_chroot_proc
-    fi
+    prepare_chroot_proc
     cp /etc/resolv.conf "$DIR/etc/"
 
     # Always install at least base pkgs
@@ -141,9 +142,8 @@ if [ -n "$USE_QUBES_REPO_VERSION" ]; then
     fi
 fi
 
-if ! [ -r "$DIR/proc/cpuinfo" ]; then
-    prepare_chroot_proc
-fi
+prepare_chroot_proc
+prepare_chroot_dev
 
 if ! [ -d "$DIR"/tmp/qubes-packages-mirror-repo/rpm ]; then
     mkdir -p "$DIR"/tmp/qubes-packages-mirror-repo

--- a/template_scripts/01_install_core.sh
+++ b/template_scripts/01_install_core.sh
@@ -10,7 +10,6 @@ cp "${SCRIPTSDIR}/resolv.conf" "${INSTALLDIR}/etc/"
 chmod 644 "${INSTALLDIR}/etc/resolv.conf"
 cp "${SCRIPTSDIR}/network" "${INSTALLDIR}/etc/sysconfig/"
 chmod 644 "${INSTALLDIR}/etc/sysconfig/network"
-cp -a /dev/null /dev/zero /dev/random /dev/urandom "${INSTALLDIR}/dev/"
 
 export YUM0=${PWD}/pkgs-for-template
 yumInstall $YUM


### PR DESCRIPTION
Creating and populating our own /dev doesn't work when building
in Qubes 4.1, because we mount the home partition with nodev
option.