### PR TITLE
prepare-chroot-base: check if required dev are present

### DIFF
--- a/prepare-chroot-base
+++ b/prepare-chroot-base
@@ -217,7 +217,7 @@ if ! [ -f "${INSTALLDIR}/tmp/.prepared_base" ]; then
     # Prepare /dev nodes
     mkdir -p "${INSTALLDIR}/dev/"
     for f in null urandom zero random console; do
-        cp -a /dev/$f "$INSTALLDIR/dev/"
+        cp -a "/dev/$f" "$INSTALLDIR/dev/" || true
     done
 
     # Create loop devices as much as Mock does


### PR DESCRIPTION
In docker /dev/console is not available. Don't fail for that.