### PR TITLE
RPM builder hardening

### DIFF
--- a/Makefile.rpmbuilder
+++ b/Makefile.rpmbuilder
@@ -199,7 +199,7 @@ else
 		if [ "$${pkg##*.}" = "buildinfo" ]; then \
 			$(RPM_PLUGIN_DIR)scripts/update-rpmbuildinfo "$$pkg" | $(BUILDINFO_SIGN_CMD) > "$$pkg".tmp && \
 			mv -f "$$pkg".tmp "$$pkg"; \
-		elif ! rpm -K $$pkg | grep -qi pgp; then \
+		elif [ "$$(rpmkeys --checksig -- "$pkg")" != "$pkg: digests signatures OK"; then \
 			setsid -w rpmsign $(RPMSIGN_OPTS) --addsign $$pkg </dev/null || exit 1; \
 		fi; \
 	done

--- a/prepare-chroot-base
+++ b/prepare-chroot-base
@@ -15,7 +15,7 @@ DIST=$2
 
 DOWNLOADDIR="${CACHEDIR}/base_rpms"
 
-YUM=dnf
+YUM=(dnf)
 
 if [ "${DIST#fc}" != "${DIST}" ]; then
     DISTRIBUTION="fedora"
@@ -26,7 +26,7 @@ if [ "${DIST#centos}" != "${DIST}" ]; then
     DISTRIBUTION="centos"
     DIST_VER="${DIST#centos}"
     if [ "$DIST_VER" = "7" ]; then
-        YUM=yum
+        YUM=(yum)
     fi
 fi
 
@@ -36,13 +36,21 @@ else
     YUM_BOOTSTRAP_CONF=yum-bootstrap-${DISTRIBUTION}.conf
 fi
 
-YUM=(yum "--downloaddir=$DOWNLOADDIR" --downloadonly install)
-if type dnf >/dev/null 2>/dev/null; then
-    YUM=(dnf $YUM_OPTS --releasever "$DIST_VER" "--downloaddir=$DOWNLOADDIR" --downloadonly install)
-elif type yumdownloader >/dev/null 2>/dev/null; then
-    # debian does not have --downloadonly plugin
-    YUM=(yumdownloader -q --resolve "--destdir=$DOWNLOADDIR")
-fi
+case ${YUM[0]} in
+(dnf)
+    YUM+=($YUM_OPTS --releasever "$DIST_VER" "--downloaddir=$DOWNLOADDIR" --downloadonly install)
+    ;;
+(yum)
+    YUM+=("--downloaddir=$DOWNLOADDIR" --downloadonly install)
+    if type yumdownloader >/dev/null 2>/dev/null; then
+        # debian does not have --downloadonly plugin
+        YUM=(yumdownloader -q --resolve "--destdir=$DOWNLOADDIR")
+    fi
+    ;;
+(*)
+    exit 1
+    ;;
+esac
 
 if ! [ -f "${INSTALLDIR}/tmp/.prepared_base" ]; then
     echo "-> Initializing RPM database..."
@@ -74,28 +82,28 @@ if ! [ -f "${INSTALLDIR}/tmp/.prepared_base" ]; then
     echo "-> Retrieving core RPM packages..."
 
     if [ "${DISTRIBUTION}" = "fedora" ]; then
-        INITIAL_PACKAGES="filesystem setup fedora-release dnf dnf-plugins-core"
+        INITIAL_PACKAGES=(filesystem setup fedora-release dnf dnf-plugins-core)
         if [ "${DIST_VER}" -ge 25 ]; then
             # avoid pulling in glibc-all-langpacks to save space
-            INITIAL_PACKAGES="$INITIAL_PACKAGES glibc-langpack-en"
+            INITIAL_PACKAGES+=(glibc-langpack-en)
         fi
         if [ "${DIST_VER}" -eq 25 ]; then
             # libcrypt conflicts with libcrypt-nss and yumdownloader is stupid
             # enough to try them both
-            INITIAL_PACKAGES="--exclude=libcrypt $INITIAL_PACKAGES"
+            INITIAL_PACKAGES=(--exclude=libcrypt "${INITIAL_PACKAGES[@]}")
         fi
 
         if [ "${DIST_VER}" -ge 26 ]; then
             # coreutils conflicts with coreutils-single
-            INITIAL_PACKAGES="--exclude=coreutils-single $INITIAL_PACKAGES"
+            INITIAL_PACKAGES=(--exclude=coreutils-single "${INITIAL_PACKAGES[@]}")
         fi
 
         if [ "${DIST_VER}" -ge 27 ]; then
             # curl-minimal conflicts with curl, same for libcurl
-            INITIAL_PACKAGES="--exclude=curl --exclude=libcurl $INITIAL_PACKAGES"
+            INITIAL_PACKAGES=(--exclude=curl --exclude=libcurl "${INITIAL_PACKAGES[@]}")
         fi
 
-        mkdir -p "${DOWNLOADDIR}"
+        mkdir -p -- "${DOWNLOADDIR}"
         yumconf=$(mktemp)
 
         if [ "x${FEDORA_MIRROR}" != "x" ]; then
@@ -120,20 +128,20 @@ if ! [ -f "${INSTALLDIR}/tmp/.prepared_base" ]; then
     fi
 
     if [ "${DISTRIBUTION}" = "centos" ]; then
-        INITIAL_PACKAGES="filesystem setup epel-release"
+        INITIAL_PACKAGES=(filesystem setup epel-release)
         YUM_OPTS+=(--setopt=repo_gpgcheck=True)
         if [ "$DIST_VER" = "7" ]; then
-            INITIAL_PACKAGES="$INITIAL_PACKAGES centos-release yum yum-utils yum-plugin-copr centos-release-xen-412"
+            INITIAL_PACKAGES+=(centos-release yum yum-utils yum-plugin-copr centos-release-xen-412)
         else
             # coreutils conflicts with coreutils-single
-            INITIAL_PACKAGES="--exclude=coreutils-single $INITIAL_PACKAGES"
-            INITIAL_PACKAGES="$INITIAL_PACKAGES centos-release-stream dnf dnf-plugins-core"
+            INITIAL_PACKAGES=(--exclude=coreutils-single "${INITIAL_PACKAGES[@]}")
+            INITIAL_PACKAGES+=(centos-release-stream dnf dnf-plugins-core)
         fi
 
         # Add groupadd, su etc.
-        INITIAL_PACKAGES="$INITIAL_PACKAGES shadow-utils util-linux"
+        INITIAL_PACKAGES+=(shadow-utils util-linux)
 
-        mkdir -p "${DOWNLOADDIR}"
+        mkdir -p -- "${DOWNLOADDIR}"
         yumconf=$(mktemp)
         yumconftmp=$(mktemp)
 
@@ -172,9 +180,8 @@ if ! [ -f "${INSTALLDIR}/tmp/.prepared_base" ]; then
         fi
     fi
 
-    # shellcheck disable=SC2086
-    $YUM "${YUM_OPTS[@]}" -c "$yumconf" -y \
-        --installroot="${INSTALLDIR}" ${INITIAL_PACKAGES}
+    "${YUM[@]}" "${YUM_OPTS[@]}" -c "$yumconf" -y \
+        --installroot="${INSTALLDIR}" "${INITIAL_PACKAGES[@]}"
     rm -f "$yumconf"
 
     echo "-> Verifying signatures..."

--- a/prepare-chroot-base
+++ b/prepare-chroot-base
@@ -13,16 +13,6 @@ PLUGIN_DIR=$(dirname "$0")
 INSTALLDIR=$1
 DIST=$2
 
-RPM_VERSION="$(rpm --version | awk '{print $3}')"
-
-if [ "$(printf '%s\n' "$RPM_VERSION" "4.14.0" | sort -V | head -n1)" = "4.14.0" ]; then
-    PGP_INVALID='SIGNATURES NOT OK'
-    PGP_SIGNED='signatures OK'
-else
-    PGP_INVALID='PGP'
-    PGP_SIGNED=' pgp '
-fi
-
 DOWNLOADDIR="${CACHEDIR}/base_rpms"
 
 YUM=dnf
@@ -46,27 +36,24 @@ else
     YUM_BOOTSTRAP_CONF=yum-bootstrap-${DISTRIBUTION}.conf
 fi
 
-YUM="yum --downloaddir=${DOWNLOADDIR} --downloadonly install"
+YUM=(yum "--downloaddir=$DOWNLOADDIR" --downloadonly install)
 if type dnf >/dev/null 2>/dev/null; then
-    YUM="dnf $YUM_OPTS --releasever ${DIST_VER} --downloaddir=${DOWNLOADDIR} --downloadonly install"
+    YUM=(dnf $YUM_OPTS --releasever "$DIST_VER" "--downloaddir=$DOWNLOADDIR" --downloadonly install)
 elif type yumdownloader >/dev/null 2>/dev/null; then
     # debian does not have --downloadonly plugin
-    YUM="yumdownloader -q --resolve --destdir=${DOWNLOADDIR}"
+    YUM=(yumdownloader -q --resolve "--destdir=$DOWNLOADDIR")
 fi
 
 if ! [ -f "${INSTALLDIR}/tmp/.prepared_base" ]; then
     echo "-> Initializing RPM database..."
-    RPM_OPTS=()
-    YUM_OPTS=()
-    if [ -e /etc/debian_version ] || grep -q openSUSE /etc/os-release; then
-        # Debian by default keep rpmdb in ~/.rpmdb
-        # OpenSUSE by default keep rpmdb in /usr/lib/sysimage/rpm
-        RPM_OPTS+=("--define=_dbpath %{_var}/lib/rpm")
-    fi
+    # We ALWAYS ALWAYS ALWAYS want signature checks.
+    RPM_OPTS=('--define=_pkgverify_level all')
+    # Delta RPMs and zchunk are unnecessary attack surface
+    YUM_OPTS=(--setopt=deltarpm=False --setopt=deltarpm_percentage=0 --setopt=zchunk=0)
+    # Debian by default keep rpmdb in ~/.rpmdb
+    # OpenSUSE by default keep rpmdb in /usr/lib/sysimage/rpm
+    RPM_OPTS+=("--define=_dbpath %{_var}/lib/rpm")
     if grep -q openSUSE /etc/os-release; then
-        # zchunk is broken on OpenSUSE (at least together with Fedora repos):
-        # https://bugzilla.opensuse.org/1160702
-        YUM_OPTS+=("--setopt=zchunk=0")
         # Since OpenSUSE enable gpgcheck by default, make it find the keys
         mkdir -p "${INSTALLDIR}/usr/lib/sysimage"
         ln -ns ../../../var/lib/rpm "${INSTALLDIR}/usr/lib/sysimage/rpm"
@@ -74,12 +61,12 @@ if ! [ -f "${INSTALLDIR}/tmp/.prepared_base" ]; then
     rpm "${RPM_OPTS[@]}" --initdb --root="${INSTALLDIR}"
 
     if [ "${DISTRIBUTION}" = "fedora" ]; then
-        rpm "${RPM_OPTS[@]}" --import --root="${INSTALLDIR}" \
+        rpm "${RPM_OPTS[@]}" --import --root="${INSTALLDIR}" -- \
             "${PLUGIN_DIR}/keys/RPM-GPG-KEY-fedora-${DIST_VER}-primary"
     fi
 
     if [ "${DISTRIBUTION}" = "centos" ]; then
-        rpm "${RPM_OPTS[@]}" --import --root="${INSTALLDIR}" \
+        rpm "${RPM_OPTS[@]}" --import --root="${INSTALLDIR}" -- \
             "${PLUGIN_DIR}/keys/RPM-GPG-KEY-CentOS-${DIST_VER}"\
             "${PLUGIN_DIR}/keys/RPM-GPG-KEY-EPEL-${DIST_VER}"
     fi
@@ -134,7 +121,7 @@ if ! [ -f "${INSTALLDIR}/tmp/.prepared_base" ]; then
 
     if [ "${DISTRIBUTION}" = "centos" ]; then
         INITIAL_PACKAGES="filesystem setup epel-release"
-
+        YUM_OPTS+=(--setopt=repo_gpgcheck=True)
         if [ "$DIST_VER" = "7" ]; then
             INITIAL_PACKAGES="$INITIAL_PACKAGES centos-release yum yum-utils yum-plugin-copr centos-release-xen-412"
         else
@@ -193,16 +180,11 @@ if ! [ -f "${INSTALLDIR}/tmp/.prepared_base" ]; then
     echo "-> Verifying signatures..."
     set +x
     for file in "${DOWNLOADDIR}"/*; do
-        result=$(rpm "${RPM_OPTS[@]}" --root="${INSTALLDIR}" --checksig "${file}") || {
+        result=$(rpm "${RPM_OPTS[@]}" --root="${INSTALLDIR}" --checksig -- "${file}") || {
             echo "Filename: ${file} failed verification.  Exiting!"
             exit 1
         }
-        result_status="${result##*:}"
-        echo "${result_status}" | grep -q "$PGP_INVALID" && {
-            echo "Filename: ${file} contains an invalid PGP signature. Exiting!"
-            exit 1
-        }
-        echo "${result_status}" | grep -q "$PGP_SIGNED" || {
+        [[ "$result" = "$file: digests signatures OK" ]] || {
             echo "Filename: ${file} is not signed.  Exiting!"
             exit 1
         }
@@ -229,7 +211,7 @@ if ! [ -f "${INSTALLDIR}/tmp/.prepared_base" ]; then
     done
 
     echo "-> Installing core RPM packages..."
-    rpm "${RPM_OPTS[@]}" -U --replacepkgs --root="${INSTALLDIR}" "${DOWNLOADDIR}/"*.rpm || exit 1
+    rpm "${RPM_OPTS[@]}" -U --replacepkgs --root="${INSTALLDIR}" -- "${DOWNLOADDIR}/"*.rpm || exit 1
 
     if grep -q openSUSE /etc/os-release; then
         # Build the rpmdb again, in case of huge rpm version difference that makes

--- a/prepare-chroot-base
+++ b/prepare-chroot-base
@@ -141,7 +141,6 @@ if ! [ -f "${INSTALLDIR}/tmp/.prepared_base" ]; then
 
     if [ "${DISTRIBUTION}" = "centos" ]; then
         INITIAL_PACKAGES=(filesystem setup epel-release)
-        YUM_OPTS+=(--setopt=repo_gpgcheck=True)
         if [ "$DIST_VER" = "7" ]; then
             INITIAL_PACKAGES+=(centos-release yum yum-utils yum-plugin-copr centos-release-xen-412)
         else

--- a/prepare-chroot-base
+++ b/prepare-chroot-base
@@ -8,6 +8,18 @@ else
     YUM_OPTS="$YUM_OPTS -q"
 fi
 
+set -o pipefail
+rpm_version=$(rpm --version)
+if ! [[ "$rpm_version" =~ ^RPM\ version\ ([0-9][0-9.]*)$ ]]; then
+    echo 'Bad RPM version' >&2
+    exit 1
+fi
+version=$(printf '%s\n4.14.2.0\n' "${BASH_REMATCH[1]}"|sort -V)
+if [[ "$version" = 4.14.2.0 ]]; then
+    echo 'Sorry, your RPM version is too old (need at least 4.14.2.1)'>&2
+    exit 1
+fi
+
 PLUGIN_DIR=$(dirname "$0")
 
 INSTALLDIR=$1


### PR DESCRIPTION
We *always* want RPM signature verification so hard-require it
everywhere we can.  Also turn off unnecessary attack surface in DNF and
check metadata signatures on CentOS.