### PR TITLE
Switch from wget to curl

### DIFF
--- a/scripts/generate-hashes-from-sources
+++ b/scripts/generate-hashes-from-sources
@@ -17,7 +17,11 @@ source "$scriptdir/functions.sh"
 
 if exist_url "$fedora_sources"; then
     tmpsources="$(mktemp)"
-    wget -q "$fedora_sources" -O "$tmpsources"
+    if [ -n "${REPO_PROXY+x}" ]; then
+        curl --proto '=https' --http1.1 --tlsv1.2 -sSo "$tmpsources" --proxy "$REPO_PROXY" -- "$fedora_sources"
+    else
+        curl --proto '=https' --http1.1 --tlsv1.2 -sSo "$tmpsources" -- "$fedora_sources"
+    fi
 
     while read -r untrusted_src
     do

--- a/template_scripts/packages_centos.list
+++ b/template_scripts/packages_centos.list
@@ -30,7 +30,7 @@ thunderbird
 tree
 unzip
 vim-enhanced
-wget
+curl
 xorg-x11-fonts-100dpi
 xorg-x11-fonts-Type1
 xterm

--- a/template_scripts/packages_centos7.list
+++ b/template_scripts/packages_centos7.list
@@ -18,7 +18,7 @@ man-db
 man-pages
 zip
 unzip
-wget
+curl
 wireless-tools
 iw
 attr

--- a/template_scripts/packages_centos7_xfce.list
+++ b/template_scripts/packages_centos7_xfce.list
@@ -22,7 +22,7 @@ man-db
 man-pages
 zip
 unzip
-wget
+curl-minimal
 iw
 attr
 dos2unix
@@ -32,7 +32,7 @@ ristretto
 pragha
 atril
 gnome-keyring-pam
-wget
+curl-minimal
 --exclude=kdegames
 --exclude=firstboot
 --exclude=xorg-x11-drv-nouveau

--- a/template_scripts/packages_centos_xfce.list
+++ b/template_scripts/packages_centos_xfce.list
@@ -23,7 +23,7 @@ thunderbird
 tree
 unzip
 vim-enhanced
-wget
+curl-minimal
 xorg-x11-fonts-100dpi
 xorg-x11-fonts-Type1
 xterm

--- a/template_scripts/packages_fc.list
+++ b/template_scripts/packages_fc.list
@@ -31,7 +31,7 @@ thunderbird
 tree
 unzip
 vim-enhanced
-wget
+curl-minimal
 wireless-tools
 xorg-x11-fonts-100dpi
 xorg-x11-fonts-Type1

--- a/template_scripts/packages_fc_xfce.list
+++ b/template_scripts/packages_fc_xfce.list
@@ -27,7 +27,7 @@ thunderbird
 tree
 unzip
 vim-enhanced
-wget
+curl-minimal
 wireless-tools
 xorg-x11-fonts-100dpi
 xorg-x11-fonts-Type1


### PR DESCRIPTION
curl has a better security track record than wget, and on Fedora uses a
better TLS library (OpenSSL instead of GnuTLS).  This change also adds
REPO_PROXY support.