### PR TITLE
Always build the RPMDB from scratch

### DIFF
--- a/prepare-chroot-base
+++ b/prepare-chroot-base
@@ -190,7 +190,7 @@ if ! [ -f "${INSTALLDIR}/tmp/.prepared_base" ]; then
     echo "-> Verifying signatures..."
     set +x
     for file in "${DOWNLOADDIR}"/*; do
-        result=$(rpm "${RPM_OPTS[@]}" --root="${INSTALLDIR}" --checksig -- "${file}") || {
+        result=$(rpmkeys "${RPM_OPTS[@]}" --root="${INSTALLDIR}" --checksig -- "${file}") || {
             echo "Filename: ${file} failed verification.  Exiting!"
             exit 1
         }

--- a/template_scripts/01_install_core.sh
+++ b/template_scripts/01_install_core.sh
@@ -6,14 +6,12 @@ source "${SCRIPTSDIR}/distribution.sh"
 export YUM_OPTS
 ${SCRIPTSDIR}/../prepare-chroot-base "${INSTALLDIR}" "${DIST}"
 
-if grep -q openSUSE /etc/os-release; then
-    # Build the rpmdb again, in case of huge rpm version difference that makes
-    # rpmdb --rebuilddb doesn't work anymore. Export using rpm from outside
-    # chroot and import using rpm from within chroot
-    rpmdb "${RPM_OPTS[@]}" --root="${INSTALLDIR}" --exportdb > "${CACHEDIR}/rpmdb.export" || exit 1
-    rm -rf "${INSTALLDIR}/var/lib/rpm"
-    chroot "${INSTALLDIR}" rpmdb --importdb < "${CACHEDIR}/rpmdb.export" || exit 1
-fi
+# Build the rpmdb again, in case of huge rpm version difference that makes
+# rpmdb --rebuilddb doesn't work anymore. Export using rpm from outside
+# chroot and import using rpm from within chroot
+rpmdb "${RPM_OPTS[@]}" --root="${INSTALLDIR}" --exportdb > "${CACHEDIR}/rpmdb.export" || exit 1
+rm -rf "${INSTALLDIR}/var/lib/rpm"
+chroot "${INSTALLDIR}" rpmdb --importdb < "${CACHEDIR}/rpmdb.export" || exit 1
 
 # remove systemd-resolved symlink
 rm -f "${INSTALLDIR}/etc/resolv.conf"


### PR DESCRIPTION
Fedora 34 does not support the old Berkeley DB RPMDB, so we need to
rebuild the RPMDB from scratch.

Suggested-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>