### PR TITLE
Add old-style header+payload signatures

### DIFF
--- a/Makefile.rpmbuilder
+++ b/Makefile.rpmbuilder
@@ -200,7 +200,7 @@ else
 			$(RPM_PLUGIN_DIR)scripts/update-rpmbuildinfo "$$pkg" | $(BUILDINFO_SIGN_CMD) > "$$pkg".tmp && \
 			mv -f "$$pkg".tmp "$$pkg"; \
 		elif [ "$$(rpmkeys --checksig -- "$$pkg")" != "$$pkg: digests signatures OK" ]; then \
-			setsid -w rpmsign $(RPMSIGN_OPTS) --addsign $$pkg </dev/null || exit 1; \
+			setsid -w rpmsign $(RPMSIGN_OPTS) --addsign $(and $(filter fc25,$(DIST)),--rpmv3) -- "$$pkg" </dev/null || exit 1; \
 		fi; \
 	done
 endif


### PR DESCRIPTION
The version of RPM in R4.0.4 cannot verify packages without them,
causing fresh R4.0.4 installs (such as from an ISO) to fail with an
error saying that the package was unsigned.

Fixes QubesOS/qubes-issues#6619.