### PR TITLE
Makefile.builder: enforce condition making plugin available

### DIFF
--- a/Makefile.builder
+++ b/Makefile.builder
@@ -6,7 +6,7 @@ else ifneq (,$(findstring centos,$(DIST)))
     DISTRIBUTION := centos
 endif
 
-ifneq (,$(DISTRIBUTION))
+ifneq (,$(findstring $(DISTRIBUTION),fedora centos-stream centos))
     RPM_PLUGIN_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
     BUILDER_MAKEFILE = $(RPM_PLUGIN_DIR)Makefile.rpmbuilder
     TEMPLATE_SCRIPTS = $(RPM_PLUGIN_DIR)template_scripts


### PR DESCRIPTION
It leads to conflicting debian and rpm plugins while building Debian
based templates because DISTRIBUTION can be defined previously and
checking for emptiness is not enough.