### PR TITLE
fix: Allow signing *.buildinfo with SplitGPG setup

### DIFF
--- a/Makefile.rpmbuilder
+++ b/Makefile.rpmbuilder
@@ -89,7 +89,7 @@ endif
 RPM_BUILD_DEFINES += --define "dist .$(DIST_TAG)"
 RPM_QUERY_DEFINES += --define "dist .$(DIST_TAG)"
 
-BUILDINFO_SIGN_CMD ?= $(firstword $(GNUPG) gpg2)
+BUILDINFO_SIGN_CMD ?= $(shell rpm --eval %{__gpg})
 BUILDINFO_SIGN_CMD += --clearsign
 RPMSIGN_OPTS ?=
 RPMSIGN_OPTS += --digest-algo=sha256


### PR DESCRIPTION
Issue: Signing *.buildinfo is hardcoded to `$(GNUPG)`.

In the SplitGPG setup we rely on the RPM macro `__gpg` to use the
`qubes-gpg-client-wrapper`. By default if the macro is not set rpm
returns (@least here on fc33) `gpg2`.

Solution: Relegate it to `rpm` like we do in the lines bellow for
signing packages.
