### PR TITLE
get_sources_from_srpm: ensure to enable needed repo only

### DIFF
--- a/scripts/get_sources_from_srpm
+++ b/scripts/get_sources_from_srpm
@@ -47,7 +47,7 @@ if [ "x$src_file" != "x" ] && [ "x$releasever" != "x" ]; then
     # download rpm
     tmpdir="$(mktemp -d -p "$localdir")"
     # shellcheck disable=SC2086
-    dnf -q download --destdir="$tmpdir" --source --releasever="$releasever" "$package"
+    dnf -q download --disablerepo=* --enablerepo=fedora-source --enablerepo=updates-source --destdir="$tmpdir" --source --releasever="$releasever" "$package"
     mv "$tmpdir/$src_rpm" "$tmpdir/$src_rpm.UNTRUSTED"
 
     # check signature


### PR DESCRIPTION
We download from Fedora only. It prevents DNF issues on non-Fedora
platform like CentOS.