### PR TITLE
Exclude xfce4-screensaver from the Xfce template

### DIFF
--- a/template_scripts/packages_fc_xfce.list
+++ b/template_scripts/packages_fc_xfce.list
@@ -73,6 +73,7 @@ zip
 --exclude=unoconv
 --exclude=vinagre
 --exclude=xfce4-sensors-plugin
+--exclude=xfce4-screensaver
 --exclude=xorg-x11-drv-nouveau
 --exclude=yum-utils
 --exclude=pipewire-pulseaudio


### PR DESCRIPTION
Fixes QubesOS/qubes-issues#6810