### PR TITLE
Makefile-mock: fail with a clear error when mock is not installed.

### DIFF
--- a/Makefile-mock.rpmbuilder
+++ b/Makefile-mock.rpmbuilder
@@ -14,6 +14,9 @@ endif
 # Fedora /usr/bin/mock is a (consolehelper) wrapper, which among other things,
 # strips environment variables
 MOCK ?= $(firstword $(wildcard /usr/libexec/mock/mock /usr/sbin/mock))
+ifeq (,$(MOCK))
+$(error package 'mock' must be installed)
+endif
 
 YUM ?= dnf
 ifeq ($(shell rpm --eval %centos), 7)


### PR DESCRIPTION
"mock" is not included in the "make install-deps" set, so the build
with `USE_DIST_BUILD_TOOLS=1` would fail as:

  mkdir -p /home/user/qubes-builder/chroot-dom0-fc32/home/user/qubes-src
  sudo DIST=fc32 PACKAGE_SET=dom0 RPM_PLUGIN_DIR=/home/user/qubes-builder/qubes-src/builder-rpm/ USE_QUBES_REPO_VERSION= BUILDER_REPO_DIR=/home/user/qubes-builder/qubes-packages-mirror-repo/dom0-fc32 CACHEDIR=/home/user/qubes-builder/cache/fc32 CHROOT_DIR=/home/user/qubes-builder/chroot-dom0-fc32  \
  	-v -r /home/user/qubes-builder/qubes-src/builder-rpm//mock-fedora.cfg \
  	--define "fedora 32" --define "dist .fc32" \
  	--dnf \
  	--disablerepo=builder-local \
  	--init
  sudo: unrecognized option '--define'
  usage: sudo -h | -K | -k | -V
  usage: sudo -v [-AknS] [-g group] [-h host] [-p prompt] [-u user]
  usage: sudo -l [-AknS] [-g group] [-h host] [-p prompt] [-U user] [-u user] [command]
  usage: sudo [-AbEHknPS] [-r role] [-t type] [-C num] [-D directory] [-g group] [-h host] [-p prompt] [-R directory] [-T timeout] [-u user] [VAR=value] [-i|-s] [<command>]
  usage: sudo -e [-AknS] [-r role] [-t type] [-C num] [-D directory] [-g group] [-h host] [-p prompt] [-R directory] [-T timeout] [-u user] file ...
  make[1]: *** [/home/user/qubes-builder/qubes-src/builder-rpm/Makefile-mock.rpmbuilder:54: /home/user/qubes-builder/chroot-dom0-fc32/home/user/.prepared_mock] Error 1
  make[1]: Leaving directory '/home/user/qubes-builder'

Signed-off-by: Yann Dirson <ydirson@free.fr>