### PR TITLE
Fix double parsing spec file

### DIFF
--- a/Makefile-legacy.rpmbuilder
+++ b/Makefile-legacy.rpmbuilder
@@ -48,7 +48,7 @@ endif
 dist-build-dep: refresh-update.$(YUM) dist-build-dep$(suffix $(PACKAGE))
 
 dist-build-dep.spec:
-	sudo $(CHROOT_ENV) chroot $(CHROOT_DIR) su -c 'cd "$(DIST_SRC)"; rpmspec -P --define "debug_package %{nil}" $(RPM_QUERY_DEFINES) $(PACKAGE) > $(PACKAGE).parsed' - $(RUN_AS_USER)
+	sudo $(CHROOT_ENV) chroot $(CHROOT_DIR) su -c 'cd "$(DIST_SRC)" && sed 's:%%:%%%%:' $(PACKAGE) > $(PACKAGE).tmp && rpmspec -P --define "debug_package %{nil}" $(RPM_QUERY_DEFINES) $(PACKAGE).tmp > $(PACKAGE).parsed' - $(RUN_AS_USER)
 	sudo $(CHROOT_ENV) $(YUM_BUILDDEP) $(YUM_OPTS) $(RPM_BUILD_EXTRA_DEFINES) -y $(CHROOT_DIR)$(DIST_SRC)/$(PACKAGE).parsed
 
 dist-build-dep.rpm:


### PR DESCRIPTION
The legacy builder parses the spec file twice: once inside the chroot to
resolve all the macros in the correct environment, and then the second
time outside to install build deps. This mostly works, with exception to
the case of escaped '%' (as '%%') - if the spec is parsed twice, it gets
unescaped. Workaround this by double escaping before double parsing.

Fixes QubesOS/qubes-issues#6957