### PR TITLE
04_install_qubes.sh: mitigate device busy for Stream 8

### DIFF
--- a/template_rpm/04_install_qubes.sh
+++ b/template_rpm/04_install_qubes.sh
@@ -121,6 +121,7 @@ if ! containsFlavor "minimal" && [ "0$TEMPLATE_ROOT_WITH_PARTITIONS" -eq 1 ]; th
     chroot_cmd grub2-install --target=i386-pc "$dev" || RETCODE=1
     chroot_cmd grub2-mkconfig -o /boot/grub2/grub.cfg || RETCODE=1
     fuser -kMm "${INSTALL_DIR}"
+    sleep 3
     chroot_cmd umount /sys /dev
 fi
 


### PR DESCRIPTION
For some unknown reason, there is still remaining processes for Centos Stream 8 that prevent to umount /dev. Waiting looks sufficient to let some processes to finish. A better approach needs to be found.