### PR TITLE
Do not exclude pipewire in templates for R4.2

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,8 +10,6 @@ include:
   - project: 'QubesOS/qubes-continuous-integration'
     file: '/r4.1/gitlab-vm-centos-chroot.yml'
   - project: 'QubesOS/qubes-continuous-integration'
-    file: '/r4.1/gitlab-vm-centos-build-template.yml'
-  - project: 'QubesOS/qubes-continuous-integration'
     file: '/r4.2/gitlab-base.yml'
   - project: 'QubesOS/qubes-continuous-integration'
     file: '/r4.2/gitlab-vm-fedora-build-template.yml'

--- a/scripts/prepare-chroot-base
+++ b/scripts/prepare-chroot-base
@@ -89,9 +89,11 @@ if ! [ -f "${INSTALL_DIR}/tmp/.prepared_base" ]; then
         # curl-minimal conflicts with curl, same for libcurl
         INITIAL_PACKAGES+=(--exclude=curl --exclude=libcurl)
 
-        # For Fedora 34+ we try to exclude pipewire until we switch
-        # to it completely.
-        INITIAL_PACKAGES+=(--exclude=pipewire-*)
+        if [ "$RELEASE" == 4.1 ]; then
+            # For Fedora 34+ we try to exclude pipewire until we switch
+            # to it completely.
+            INITIAL_PACKAGES+=(--exclude=pipewire-*)
+        fi
 
         mkdir -p -- "${DOWNLOAD_DIR}"
         yumconf=$(mktemp)

--- a/template_rpm/distribution.sh
+++ b/template_rpm/distribution.sh
@@ -261,6 +261,14 @@ function installPackages() {
         declare -a packages
         readarray -t packages < "${package_list}"
 
+        # Exclude pipewire only on Qubes 4.1, this used to be part of packages_list files
+        if [ "$RELEASE" == "4.1" ]; then
+            packages+=( "--exclude=pipewire"
+                        "--exclude=pipewire-utils"
+                        "--exclude=pipewire-pulseaudio"
+                        "--exclude=wireplumber" )
+        fi
+
         info "Packages: ${packages[*]}"
         yumInstall "${packages[@]}" || return $?
     done

--- a/template_rpm/packages_fedora.list
+++ b/template_rpm/packages_fedora.list
@@ -74,7 +74,6 @@ zip
 --exclude=mlocate
 --exclude=nss-mdns
 --exclude=openssh-server
---exclude=pipewire-*
 --exclude=plymouth
 --exclude=plymouth-system-theme
 --exclude=qemu-*
@@ -87,5 +86,4 @@ zip
 --exclude=webkit2gtk3-plugin-process-gtk2
 --exclude=xdg-desktop-portal*
 --exclude=xorg-x11-drv-nouveau
---exclude=wireplumber
 --exclude=yum-utils

--- a/template_rpm/packages_fedora_minimal.list
+++ b/template_rpm/packages_fedora_minimal.list
@@ -8,5 +8,3 @@ sudo
 --exclude=firewall-config,firewalld
 --exclude=gnome-boxes
 --exclude=yum-utils
---exclude=wireplumber
---exclude=pipewire-*

--- a/template_rpm/packages_fedora_xfce.list
+++ b/template_rpm/packages_fedora_xfce.list
@@ -61,7 +61,6 @@ zip
 --exclude=nss-mdns
 --exclude=openssh-server
 --exclude=PackageKit*
---exclude=pipewire-*
 --exclude=plymouth
 --exclude=plymouth-system-theme
 --exclude=qemu-*
@@ -74,6 +73,4 @@ zip
 --exclude=xfce4-sensors-plugin
 --exclude=xfce4-screensaver
 --exclude=xorg-x11-drv-nouveau
---exclude=wireplumber
 --exclude=yum-utils
---exclude=pipewire-pulseaudio


### PR DESCRIPTION
We do have pipewire agent already.

QubesOS/qubes-issues#6358