### PR TITLE
xfce: fix flatpak issue to open file dialog

### DIFF
--- a/template_rpm/packages_centos-stream_xfce.list
+++ b/template_rpm/packages_centos-stream_xfce.list
@@ -24,6 +24,7 @@ tree
 unzip
 vim-enhanced
 wget
+xdg-desktop-portal-gtk
 xorg-x11-fonts-100dpi
 xorg-x11-fonts-Type1
 xterm

--- a/template_rpm/packages_fedora_xfce.list
+++ b/template_rpm/packages_fedora_xfce.list
@@ -29,6 +29,7 @@ tree
 unzip
 vim-enhanced
 curl-minimal
+xdg-desktop-portal-gtk
 xorg-x11-fonts-100dpi
 xorg-x11-fonts-Type1
 xterm


### PR DESCRIPTION
It complains about: No such interface “org.freedesktop.impl.portal.FileChooser”