### PR TITLE
[RFC] use default-fonts meta-packages

### DIFF
--- a/template_rpm/packages_fedora.list
+++ b/template_rpm/packages_fedora.list
@@ -7,9 +7,7 @@ attr
 bc
 bzip2
 cryptsetup
-dejavu-sans-fonts
-dejavu-sans-mono-fonts
-dejavu-serif-fonts
+default-fonts
 dnf
 dnf-utils
 dos2unix

--- a/template_rpm/packages_fedora_xfce.list
+++ b/template_rpm/packages_fedora_xfce.list
@@ -8,6 +8,7 @@ attr
 bc
 bzip2
 cryptsetup
+default-fonts
 dos2unix
 firefox
 git


### PR DESCRIPTION
Fedora 39 introduces default-fonts meta-package[1].
This package pulls minimal fonts packages for all supported languages. Without this, some characters (Korean etc,) are not displayed correctly.

Size increase is about 150MiB.

QubesOS/qubes-issues#5937

[1] https://fedoraproject.org/wiki/Changes/ImproveDefaultFontHandling