### PR TITLE
Set SELinux contexts on just-extracted cache files

### DIFF
--- a/scripts/prepare-chroot-builder
+++ b/scripts/prepare-chroot-builder
@@ -65,8 +65,9 @@ prepare_chroot_proc () {
 }
 
 if ! [ -d "$INSTALL_DIR/home/user" ] && [ -r "$CHROOT_CACHE_FILE" ]; then
-    mkdir -p "$INSTALL_DIR"
-    tar xf "$CHROOT_CACHE_FILE" "$INSTALL_DIR"
+    mkdir -p -- "$INSTALL_DIR"
+    tar -xf "$CHROOT_CACHE_FILE" -- "$INSTALL_DIR"
+    setfiles -r "$INSTALL_DIR" -- '/etc/selinux/targeted/contexts/files/file_contexts' "$INSTALL_DIR"
 fi
 
 # Bootstrap chroot


### PR DESCRIPTION
This uses the contexts from the host, which won't be the same as those of the distribution, but are guaranteed to be available and will hopefully be similar.  Proper contexts will be set at the end of the build.

Fixes: QubesOS/qubes-issues#9219

Not tested!