### PR TITLE
Disable zchunk and deltarpm before first template boot

### DIFF
--- a/dnf/bootstrap-dnf-centos-stream.conf
+++ b/dnf/bootstrap-dnf-centos-stream.conf
@@ -10,6 +10,8 @@ repo_gpgcheck=1
 plugins=1
 installonly_limit=3
 color=never
+deltarpm=False
+zchunk=False
 
 reposdir=/var/empty
 

--- a/dnf/bootstrap-dnf-fedora.conf
+++ b/dnf/bootstrap-dnf-fedora.conf
@@ -9,6 +9,8 @@ gpgcheck=1
 plugins=1
 installonly_limit=3
 color=never
+deltarpm=False
+zchunk=False
 
 reposdir=/var/empty
 

--- a/scripts/prepare-chroot-base
+++ b/scripts/prepare-chroot-base
@@ -52,7 +52,9 @@ else
 fi
 
 DNF=dnf
-DNF_OPTS+=(--releasever "$DIST_VER" --installroot="${INSTALL_DIR}" "--downloaddir=$DOWNLOAD_DIR" --downloadonly)
+# Delta RPMs and zchunk are unnecessary attack surface
+DNF_SEC_OPTS=(--setopt=deltarpm=False --setopt=deltarpm_percentage=0 --setopt=zchunk=0)
+DNF_OPTS+=(--releasever "$DIST_VER" --installroot="${INSTALL_DIR}" "--downloaddir=$DOWNLOAD_DIR" --downloadonly "${DNF_SEC_OPTS[@]}")
 
 # Ensure INSTALL_DIR exists
 mkdir -p "$INSTALL_DIR"
@@ -61,8 +63,6 @@ if ! [ -f "${INSTALL_DIR}/tmp/.prepared_base" ]; then
     echo "INFO: Initializing RPM database..."
     # We want signature checks.
     RPM_OPTS=('--define=_pkgverify_level all' '--define=_pkgverify_flags 0x0')
-    # Delta RPMs and zchunk are unnecessary attack surface
-    DNF_OPTS+=(--setopt=deltarpm=False --setopt=deltarpm_percentage=0 --setopt=zchunk=0)
     if [ "$(getenforce || :)" = Enforcing ]; then
         dbpath=$(rpm --eval '%{_dbpath}')
         mkdir -p "${INSTALL_DIR}${dbpath}"

--- a/template_rpm/distribution.sh
+++ b/template_rpm/distribution.sh
@@ -37,7 +37,11 @@ if [ -z "${DIST_VER}" ]; then
     error "Please provide DIST_VER in environment."
 fi
 
-DNF_OPTS=(-y --releasever "${DIST_VER}")
+DNF_OPTS=(-y
+          "--releasever=${DIST_VER}"
+          --setopt=deltarpm=False
+          --setopt=zchunk=False
+          --setopt=gpgcheck=1)
 
 if [ -n "${REPO_PROXY}" ]; then
     DNF_OPTS+=("--setopt=proxy=${REPO_PROXY}")


### PR DESCRIPTION
This disables zchunk as well as deltarpm, reducing DNF's attack surface. Since zchunk applies to metadata fetches, it must be turned off before the template is installed, as otherwise the template will use it when fetching metadata to check for updates.

This also ensures that users who install packages manually before using Qubes OS's updater get a hardened DNF configuration.