### PR TITLE
Add Ptyxis to allowlisted appmenus for Fedora

### DIFF
--- a/template_rpm/appmenus_fedora_41/netvm-whitelisted-appmenus.list
+++ b/template_rpm/appmenus_fedora_41/netvm-whitelisted-appmenus.list
@@ -1,0 +1,1 @@
+org.gnome.Ptyxis.desktop

--- a/template_rpm/appmenus_fedora_41/vm-whitelisted-appmenus.list
+++ b/template_rpm/appmenus_fedora_41/vm-whitelisted-appmenus.list
@@ -1,0 +1,3 @@
+org.gnome.Ptyxis.desktop
+org.gnome.Nautilus.desktop
+org.mozilla.firefox.desktop

--- a/template_rpm/appmenus_fedora_41/whitelisted-appmenus.list
+++ b/template_rpm/appmenus_fedora_41/whitelisted-appmenus.list
@@ -1,0 +1,3 @@
+org.gnome.Ptyxis.desktop
+org.gnome.Software.desktop
+gpk-update-viewer.desktop


### PR DESCRIPTION
This is the brand-new Terminal application supplied with Fedora 41, replacing gnome-terminal there.