### PR TITLE
Support installing kernel in template even for minimal flavors

### DIFF
--- a/template_rpm/04_install_qubes.sh
+++ b/template_rpm/04_install_qubes.sh
@@ -100,7 +100,7 @@ if ! grep -q LANG= "${INSTALL_DIR}/etc/locale.conf" 2>/dev/null; then
     fi
 fi
 
-if ! containsFlavor "minimal" && [ "0$TEMPLATE_ROOT_WITH_PARTITIONS" -eq 1 ]; then
+if ! containsFlavor "minimal" || containsFlavor "install-kernel" && [ "0$TEMPLATE_ROOT_WITH_PARTITIONS" -eq 1 ]; then
     chroot_cmd mount -t sysfs sys /sys
     chroot_cmd mount -t devtmpfs none /dev
     # find the right loop device, _not_ its partition


### PR DESCRIPTION
To have a minimal template that includes kernel package, add an
"install-kernel" template option. This is especially useful for Whonix
templates (in builder-debian repo), but add this feature to builder-rpm
too for consistency.

QubesOS/qubes-issues#9570