### PR TITLE
Avoid uninitialized dnf's history.sqlite

### DIFF
--- a/template_rpm/09_cleanup.sh
+++ b/template_rpm/09_cleanup.sh
@@ -45,6 +45,13 @@ if [ -x "${INSTALL_DIR}"/usr/bin/dnf ]; then
     rm -rf "${INSTALL_DIR}"/var/cache/yum/* || :
 fi
 
+# if history.sqlite exists but isn't initialized (no tables), remove it so dnf
+# will create proper one on first start
+if [ -e "${INSTALL_DIR}/var/lib/dnf/history.sqlite" ] && \
+       [ "$(stat -c %s "${INSTALL_DIR}/var/lib/dnf/history.sqlite")" -lt 8192 ]; then
+    rm -f "${INSTALL_DIR}/var/lib/dnf/history.sqlite"*
+fi
+
 truncate --no-create --size=0 "${INSTALL_DIR}"/var/log/dnf.*
 
 if containsFlavor selinux; then


### PR DESCRIPTION
Do not leave uninitialized history.sqlite in the template. When it
doesn't exist, dnf will create it with the proper structure. But when it
exists, it will expect its tables to exist already. Empty sqlite file
(just headers) breaks this assumption resulting in update errors like:

```
fedora-41-xfce:out: Refreshing package info
fedora-41-xfce:err: History database is not writable: SQLite error on "/var/lib/dnf/history.sqlite": Executing an SQL statement failed: no such table: config
fedora-41-xfce:err: History database is not writable: SQLite error on "/var/lib/dnf/history.sqlite": Executing an SQL statement failed: no such table: config
fedora-41-xfce:err: SQLite error on "/var/lib/dnf/history.sqlite": Executing an SQL statement failed: no such table: config
```
The history.sqlite with just headers has 4096 bytes. Properly
initialized one over 100k. To be on the conservative side, set the
threshold at 8k - if it's smaller - remove it (together with sqlite's
side files).

Fixes QubesOS/qubes-issues#9744