### PR TITLE
merge Fedora appmenus

### DIFF
--- a/template_rpm/appmenus_fedora/netvm-whitelisted-appmenus.list
+++ b/template_rpm/appmenus_fedora/netvm-whitelisted-appmenus.list
@@ -1,1 +1,1 @@
-org.gnome.Terminal.desktop
+org.gnome.Ptyxis.desktop

--- a/template_rpm/appmenus_fedora/vm-whitelisted-appmenus.list
+++ b/template_rpm/appmenus_fedora/vm-whitelisted-appmenus.list
@@ -1,3 +1,3 @@
-org.gnome.Terminal.desktop
+org.gnome.Ptyxis.desktop
 org.gnome.Nautilus.desktop
-firefox.desktop
+org.mozilla.firefox.desktop

--- a/template_rpm/appmenus_fedora/whitelisted-appmenus.list
+++ b/template_rpm/appmenus_fedora/whitelisted-appmenus.list
@@ -1,3 +1,3 @@
-org.gnome.Terminal.desktop
+org.gnome.Ptyxis.desktop
 org.gnome.Software.desktop
 gpk-update-viewer.desktop

--- a/template_rpm/appmenus_fedora_40/netvm-whitelisted-appmenus.list
+++ b/template_rpm/appmenus_fedora_40/netvm-whitelisted-appmenus.list
@@ -1,1 +1,0 @@
-org.gnome.Terminal.desktop

--- a/template_rpm/appmenus_fedora_40/vm-whitelisted-appmenus.list
+++ b/template_rpm/appmenus_fedora_40/vm-whitelisted-appmenus.list
@@ -1,3 +1,0 @@
-org.gnome.Terminal.desktop
-org.gnome.Nautilus.desktop
-org.mozilla.firefox.desktop

--- a/template_rpm/appmenus_fedora_40/whitelisted-appmenus.list
+++ b/template_rpm/appmenus_fedora_40/whitelisted-appmenus.list
@@ -1,3 +1,0 @@
-org.gnome.Terminal.desktop
-org.gnome.Software.desktop
-gpk-update-viewer.desktop

--- a/template_rpm/appmenus_fedora_41/netvm-whitelisted-appmenus.list
+++ b/template_rpm/appmenus_fedora_41/netvm-whitelisted-appmenus.list
@@ -1,1 +1,0 @@
-org.gnome.Ptyxis.desktop

--- a/template_rpm/appmenus_fedora_41/vm-whitelisted-appmenus.list
+++ b/template_rpm/appmenus_fedora_41/vm-whitelisted-appmenus.list
@@ -1,3 +1,0 @@
-org.gnome.Ptyxis.desktop
-org.gnome.Nautilus.desktop
-org.mozilla.firefox.desktop

--- a/template_rpm/appmenus_fedora_41/whitelisted-appmenus.list
+++ b/template_rpm/appmenus_fedora_41/whitelisted-appmenus.list
@@ -1,3 +1,0 @@
-org.gnome.Ptyxis.desktop
-org.gnome.Software.desktop
-gpk-update-viewer.desktop

--- a/template_rpm/appmenus_fedora_42/netvm-whitelisted-appmenus.list
+++ b/template_rpm/appmenus_fedora_42/netvm-whitelisted-appmenus.list
@@ -1,1 +1,0 @@
-org.gnome.Ptyxis.desktop

--- a/template_rpm/appmenus_fedora_42/vm-whitelisted-appmenus.list
+++ b/template_rpm/appmenus_fedora_42/vm-whitelisted-appmenus.list
@@ -1,3 +1,0 @@
-org.gnome.Ptyxis.desktop
-org.gnome.Nautilus.desktop
-org.mozilla.firefox.desktop

--- a/template_rpm/appmenus_fedora_42/whitelisted-appmenus.list
+++ b/template_rpm/appmenus_fedora_42/whitelisted-appmenus.list
@@ -1,3 +1,0 @@
-org.gnome.Ptyxis.desktop
-org.gnome.Software.desktop
-gpk-update-viewer.desktop


### PR DESCRIPTION
Please merge this **after final build of F40 template**.

Appmenus for Fedora 41+ are all same.
Fedora 39 is already EoL, and Fedora 40 is near EoL.